### PR TITLE
Stop deleting invalid GP accounts when using Click deletion + "Ignore invalid GPs" + Continue

### DIFF
--- a/Scripts/1.ahk
+++ b/Scripts/1.ahk
@@ -1312,6 +1312,10 @@ checkBorder() {
 					godPackLog = GPlog.txt
 					LogToFile(logMessage, godPackLog)
 					LogToDiscord(logMessage, Screenshot("Invalid"), discordUserId, saveAccount("Invalid"))
+					if ((godPack = 3) && (!deleteXML)) {
+						; Avoid deleting this acc
+						gpFound := true
+					}
 					break
 				}
 				else {


### PR DESCRIPTION
There's an edge case here that was missed. If using "click deletion", "ignore invalid GPs", and "Continue" setting all the invalid accs are getting deleted.